### PR TITLE
[Don't approve] Update and rename how-to-verify-access.md to get-started-with-API-and…

### DIFF
--- a/get-started-with-API-and-CLI-for-VPC.md
+++ b/get-started-with-API-and-CLI-for-VPC.md
@@ -33,9 +33,9 @@ To use the CLI and API, follow the steps below.
 
 ## Processes:
 
-1. Install the infrastructure-services plugin for CLI
+1. Install the infrastructure-services plugin for IBM Cloud CLI
 
-1. Generate IAM token
+1. Generate an IAM token
 
 1. Get API access and run cURL commands
 
@@ -79,18 +79,16 @@ ibmcloud login
 ```
 {: codeblock}
 
-### Step 3: To learn how to use the commands, you can run:
-
-```
-ibmcloud is help <Command name>
-```
-
-### Step 4: Start running VPC CLI commands!
-
+### Step 3: Start running VPC CLI commands.
 ```
 ibmcloud is regions
 ibmcloud is zones _region-name_ (For example, _us-south_)
 ibmcloud is instances --json
+```
+
+To learn how to use the CLI commands, you can run
+```
+ibmcloud is help <Command name>
 ```
 
 For more details on CLI capability, see:
@@ -120,15 +118,7 @@ Once your account has been granted access, you will receive an email with the AP
 
 ### Step 1: Login into the CLI (See above) <Hotlink to anchor above?>
 
-### Step 2: Get an IBM Identity and Access Management (IAM) token and store it
-```
-iam_token=$(ibmcloud iam oauth-tokens | awk '/IAM/{ print $4; }')
-```
-{: codeblock}
-
-This command calls the IBM Cloud CLI, parses out the IAM token, and stores it in a variable you can use in later commands. To view your IAM token, run the command ``echo $iam_token``.
-
-**Note that you must repeat the preceding step to refresh your IAM token every hour, because the token expires.**
+### Step 2: Get an IBM Identity and Access Management (IAM) token and store it (See above) <Hotlink to anchor above>
 
 ### Step 3: Store the endpoint
 For `rias_endpoint`, use the API endpoint given to you during on-boarding.
@@ -141,7 +131,7 @@ rias_endpoint="<RIAS_API_ENDPOINT>"
 Run the previous command to store the value as a variable in your session. To verify that this variable was saved, run ``echo $rias_endpoint`` and make sure the response is not empty.
 
 
-### Step 4: Run a couple commands using the stored variables
+### Step 4: Run cURL commands using the stored variables
 
 #### GET Regions API
 ```

--- a/get-started-with-API-and-CLI-for-VPC.md
+++ b/get-started-with-API-and-CLI-for-VPC.md
@@ -135,7 +135,7 @@ Run the previous command to store the value as a variable in your session. To ve
 
 #### GET Regions API
 ```
-curl $rias_endpoint/v1/regions -H "X-Auth-Token: $iam_token"
+curl $rias_endpoint/v1/regions -H "Authorization: bearer $iam_token"
 ```
 {: codeblock}
 
@@ -145,7 +145,7 @@ The previous command returns the regions available for VPC, in JSON format. At l
 Note that currently, there is only one region `us-south` available.
 
 ```
-curl $rias_endpoint/v1/regions/us-south/zones -H "X-Auth-Token: $iam_token"
+curl $rias_endpoint/v1/regions/us-south/zones -H "Authorization: $iam_token"
 ```
 {: codeblock}
 
@@ -157,7 +157,7 @@ Create an IBM Cloud VPC called `my-vpc`.
 
 ```bash
 curl -X POST $rias_endpoint/v1/vpcs \
-  -H "X-Auth-Token:$iam_token" \
+  -H "Authorization:$iam_token" \
   -d '{
       	"is_default": true,
       	"name": "my-vpc"
@@ -178,7 +178,7 @@ Create a subnet in your IBM Cloud VPC. For example, let's put it in the `us-sout
 
 ```bash
 curl -X POST $rias_endpoint/v1/subnets \
-  -H "X-Auth-Token:$iam_token" \
+  -H "Authorization:$iam_token" \
   -d '{
         "name": "my-subnet",
         "ipv4_cidr_block": "10.0.1.0/24",


### PR DESCRIPTION
…-CLI-for-VPC.md

Playing with content to simplify process going from not even the IBM Cloud CLI installed to running API or CLI commands for VPC.  not sure if this is exactly a proposed change or a different page entirely